### PR TITLE
Use experiment name as subtitle for report page

### DIFF
--- a/experiments/templates/experiments/report.html
+++ b/experiments/templates/experiments/report.html
@@ -6,7 +6,7 @@
 {% block content %}
     {% trans "Experiment results" as doc_str %}
 
-    {% include "wagtailadmin/shared/header.html" with title=doc_str subtitle=experiment.control_page.title icon="doc-full-inverse" %}
+    {% include "wagtailadmin/shared/header.html" with title=doc_str subtitle=experiment.name icon="doc-full-inverse" %}
 
     <div class="nice-padding">
 


### PR DESCRIPTION
rather than the control page's title